### PR TITLE
fix: Move "gatsby-plugin-theme-ui" to root

### DIFF
--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -9,9 +9,9 @@ const lightBlue = `#66E0FF`
 const blueGray = `#282c35`
 
 export default {
-    colors: {
-        text: blueGray,
-        primary: darkBlue,
-        heading: blueGray,
-    },
+  colors: {
+    text: blueGray,
+    primary: darkBlue,
+    heading: blueGray,
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7439,11 +7439,6 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
-http-parser-js@>=0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.2.tgz#da2e31d237b393aae72ace43882dd7e270a8ff77"
-  integrity sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==
-
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -12030,7 +12025,7 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==


### PR DESCRIPTION
Hey, I just started using Gatsby today to create a quick blog! I noticed that customizing the theme didn't work out of the box. I read (I think in the 2.0 migration) that the plugin folder has to be at the root level (`src`).

Moving it fixed shadowing the preset theme for me.

Maybe I am just too dumb and the starter just doesn't work for me. If not, here you go! 🙂